### PR TITLE
bug: set proper goreleaser version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing


### PR DESCRIPTION
The [Release](https://github.com/Progressive-Insurance/terraform-provider-pgrmongodb/actions/runs/9553647930/job/26332926912) pipeline is failing with the error below. Adding the version should resolve it based on the [upgrade notes](https://goreleaser.com/blog/goreleaser-v2/#upgrading) for goreleaser v2.

```shell
only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
```