### PR TITLE
bug: update deprecated goreleaser prop

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,4 +58,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
The `skip` property was [deprecated](https://goreleaser.com/deprecations/#changelogskip) in favor of a `disable` prop. After updating the config, the `goreleaser` CLI says the configuration structure is now clean.