### PR TITLE
bug: update action, goreleaser to latest guide steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,23 +17,24 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          # Allow goreleaser to access older tag information.
           fetch-depth: 0
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
-          cache: true
+          go-version: stable
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
         id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        uses: goreleaser/goreleaser-action@v6
         with:
+          version: "~> v1"
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,11 +41,12 @@ checksum:
   algorithm: sha256
 signs:
   - artifacts: checksum
+    cmd: gpg2
     args:
       # if you are using this in a GitHub action or some other automated pipeline, you 
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
-      - "--local-user"
+      - "-u"
       - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
       - "--output"
       - "${signature}"


### PR DESCRIPTION
While researching why the release pipeline was [still failing](https://github.com/Progressive-Insurance/terraform-provider-pgrmongodb/actions/runs/9566092826/job/26370504192), I stumbled across some [updated instructions](https://github.com/goreleaser/goreleaser/blob/main/www/docs/ci/actions.md) on how to use the GitHub Action. Updated our workflow and goreleaser config to match.