### PR TITLE
bug: ensure v2 config is used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: "~> v1"
+          version: "~> v2"
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.


### PR DESCRIPTION
Missed the [updated documentation](https://github.com/goreleaser/goreleaser-action?tab=readme-ov-file#workflow) on the GitHub Action project page to update the `version` statement to `v2`. 

[Failed workflow](https://github.com/Progressive-Insurance/terraform-provider-pgrmongodb/actions/runs/9570058828/job/26383978879)