### PR TITLE
bug: save signing key to git config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
This [Stack Overflow answer](https://stackoverflow.com/a/36811656/16316064) states that the error can be caused because the signing key has not been setup in the local git config. The `ghaction-import-gpg` action has an [option](https://github.com/crazy-max/ghaction-import-gpg?tab=readme-ov-file#sign-commits) to turn this functionality on so we're going to try it 🤷🏻 